### PR TITLE
Disable colors when not in interactive terminal (#602)

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -68,7 +68,7 @@ func ConfigureLogger(logLevel Level, formatType FormatType, logTimestamp bool) {
 		logFormatter := &prefixed.TextFormatter{
 			TimestampFormat:  "2006-01-02 15:04:05",
 			FullTimestamp:    true,
-			ForceFormatting:  true,
+			ForceFormatting:  false,
 			ForceColors:      true,
 			QuoteEmptyFields: true,
 			DisableTimestamp: !logTimestamp}


### PR DESCRIPTION
Forcing colors in logrus causes color escapes sequences when logging to file or pipe.